### PR TITLE
Make using custom Jail grammars possible

### DIFF
--- a/lib/ometa/bemhtml.ometajs
+++ b/lib/ometa/bemhtml.ometajs
@@ -38,7 +38,7 @@ ometa BEMHTMLParser <: XJSTParser {
                        BEMHTMLParser._concatChildren(t, [#sub, ts])
                      } | ':' (asgnExpr:e -> [#begin, [#return, e]]
                              | stmt):c ','? ->
-                       [t, [#body, Jail.match(
+                       [t, [#body, this._jail.match(
                          c,
                          'topLevel',
                          ['_$' + (BEMHTMLParser._jailId++).toString(36)]
@@ -80,6 +80,7 @@ ometa BEMHTMLParser <: XJSTParser {
   }
 }
 
+BEMHTMLParser.prototype._jail = Jail;
 BEMHTMLParser._jailId = 0;
 
 BEMHTMLParser._transMode = function transMode(e) {


### PR DESCRIPTION
Bemhtml parser has its Jail grammar hard-coded in one of the rules. This prevents anyone who inherits from the bemhtml Parser grammar from specifying their custom Jail grammar. This tiny change should fix it. Just assign your custom jailer like so `YourParserGrammarName.prototype._jail = MyCustomJailGrammar` and you no longer have to copy-paste the `listBemMatchAndSet` rule to your grammar just for the sake of redefining the Jail. 
